### PR TITLE
Initialize the widget after document.readyState is already complete

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -25,6 +25,11 @@ async function initialize() {
     }
 }
 
-// Use readystatechange for async support
-document.addEventListener("readystatechange", initialize);
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    // Initialize if the script is appended to the DOM when document.readyState is completed
+    initialize();
+}else{
+    // Use readystatechange for async support
+    document.addEventListener("readystatechange", initialize);
+}
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -2,8 +2,9 @@ import sienna from "./sienna";
 import { getDefaultLanguage } from "./i18n/getDefaultLanguage";
 import { getScriptDataAttribute } from "./utils/getScriptDataAttribute";
 import observeHTMLLang from "./utils/observeHTMLLang";
+import {loadLanguages} from "@/i18n/Languages";
 
-function initialize() {
+async function initialize() {
     if (document.readyState === 'complete' || document.readyState === 'interactive') {
         document.removeEventListener('readystatechange', initialize);
 
@@ -13,7 +14,7 @@ function initialize() {
             offset: getScriptDataAttribute("offset")?.split(",").map(Number),
             size: getScriptDataAttribute("size")
         };
-
+        await loadLanguages();
         window.SiennaPlugin = sienna({
             options
         });

--- a/src/i18n/Languages.ts
+++ b/src/i18n/Languages.ts
@@ -63,11 +63,9 @@ export interface ILanguage {
 export const LANGUAGE_DICTIONARY: Record<string, ILanguage> = {};
 
 // @ts-ignore
-async function loadLanguages() {
+export async function loadLanguages() {
   for (const locale of locales) {
     // @ts-ignore
     LANGUAGE_DICTIONARY[locale] = (await import(`../locales/${locale}.json`)).default;
   }
 }
-
-loadLanguages();


### PR DESCRIPTION
The initialization was made adding eventListener on readystatechange, but If I add the widget to the DOM when the document.readyState is already complete, it never calls initialize.

To fix this case, I added a call to initialize if the document.readyState is already complete or interactive.
In this way I can add the wiget to the DOM after readyState already changed.
After this change, I received errors on the initialization, because it didn't wait the import of the json languages, so I moved the loadLanguages call before the renderWidget phase.