### PR TITLE
fix: first click on close button doesn't close the menu

### DIFF
--- a/src/views/menu/toggleMenu.ts
+++ b/src/views/menu/toggleMenu.ts
@@ -1,5 +1,5 @@
 import { $menu } from "./menu";
 
 export default function toggleMenu() {
-    $menu.style.display = $menu.style.display === "block" ? "none" : "block";
+    $menu.style.display = !$menu.style.display || ($menu.style.display === "block") ? "none" : "block";
 }


### PR DESCRIPTION
At the first click the button doesn't have the style block assigned, so the close click doesn't close the menu, but adds the style block. At that point another click finds the style block assigned and then the close button works.
