### PR TITLE
fix for double click to close menu

### DIFF
--- a/src/views/menu/renderMenu.ts
+++ b/src/views/menu/renderMenu.ts
@@ -23,6 +23,7 @@ import { $widget } from "../widget/widget";
 
 export default function renderMenu() {
     const $container: HTMLElement = document.createElement("div");
+    $container.style.display = 'block';
     $container.innerHTML = `<style>${css}</style>` + template;
 
     const $menu = $container.querySelector(".asw-menu");


### PR DESCRIPTION
initialize the menu with display block so the first click on the close button closes the menu right away.

Before the first click would add display block. You need another click to remove it and close the menu.