### PR TITLE
Fix getting the default lang from pluginConfig

### DIFF
--- a/src/views/menu/renderMenu.ts
+++ b/src/views/menu/renderMenu.ts
@@ -57,7 +57,7 @@ export default function renderMenu() {
 
     // *** Translations ***
     if (!LANGUAGES.some(lang => lang.code === userSettings.lang)) {
-        userSettings.lang = "en";
+        userSettings.lang = pluginConfig.lang;
     }
 
     const $lang = $menu.querySelector("#asw-language");


### PR DESCRIPTION
In this PR I changed the fallback value for `userSettings.lang` to be taken from `pluginConfig.lang` instead of just being set to `en` so setting the default language works like intended.

I noticed that you're supposed to be able to set the widgets default language through a data attribute on the script tag.
That currently doesn't work though as the language selectors default value only gets set through the user settings and those get set to english by default:
```ts
    // *** Translations ***
    if (!LANGUAGES.some(lang => lang.code === userSettings.lang)) {
        userSettings.lang = "en";
    }
```