### PR TITLE
Fix bug with default lang in renderMenu.ts

### DIFF
--- a/src/views/menu/renderMenu.ts
+++ b/src/views/menu/renderMenu.ts
@@ -56,6 +56,10 @@ export default function renderMenu() {
     }
 
     // *** Translations ***
+    if (!userSettings.lang && pluginConfig?.lang) {
+        userSettings.lang = pluginConfig.lang;
+    }
+
     if (!LANGUAGES.some(lang => lang.code === userSettings.lang)) {
         userSettings.lang = "en";
     }


### PR DESCRIPTION
The plugin is not setting the default language on widget load.

With this PR the widget will load the default language if the user has not set it yet and solves #11.