### PR TITLE
Fix host-page CSS conflicts with Shadow DOM

### DIFF
--- a/src/views/menu/renderMenu.ts
+++ b/src/views/menu/renderMenu.ts
@@ -77,7 +77,7 @@ export default function renderMenu() {
     );
 
     $container.querySelectorAll('.asw-menu-reset').forEach((el) =>
-        el.addEventListener('click', reset)
+        el.addEventListener('click', () => reset($menu))
     );
 
     // *** Controls ***
@@ -96,7 +96,7 @@ export default function renderMenu() {
             fontSize = Math.min(fontSize, 2);
             fontSize = Number(fontSize.toFixed(2));
 
-            document.querySelector(".asw-amount").textContent = `${(fontSize * 100).toFixed(0)}%`;
+            $menu.querySelector(".asw-amount").textContent = `${(fontSize * 100).toFixed(0)}%`;
 
             adjustFontSize(fontSize);
             userSettings.states.fontSize = fontSize;

--- a/src/views/menu/reset.ts
+++ b/src/views/menu/reset.ts
@@ -1,8 +1,8 @@
 import { saveUserSettings, userSettings } from "@/globals/userSettings";
 import runAccessibility from "./runAccessibility";
 
-export default function reset() {
-    document?.querySelectorAll(".asw-selected")?.forEach(el => el?.classList?.remove("asw-selected"))
+export default function reset($root: ParentNode) {
+    $root.querySelectorAll(".asw-selected").forEach(el => el.classList.remove("asw-selected"))
 
     userSettings.states = {};
     runAccessibility();

--- a/src/views/widget/widget.css
+++ b/src/views/widget/widget.css
@@ -1,3 +1,12 @@
+:host {
+    all: initial;
+    display: block;
+    color: #000;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1;
+}
+
 .asw-widget,
 .asw-menu {
     -webkit-user-select: none;

--- a/src/views/widget/widget.ts
+++ b/src/views/widget/widget.ts
@@ -8,11 +8,12 @@ import {
     pluginConfig
 } from "@/globals/pluginConfig";
 
-export let $widget: HTMLElement;
+export let $widget: ShadowRoot;
 
 export function renderWidget() {
-    $widget = document.createElement("div");
-    $widget.classList.add("asw-container");
+    const $host = document.createElement("div");
+    $host.classList.add("asw-container");
+    $widget = $host.attachShadow({ mode: "open" });
     $widget.innerHTML = `<style>${css}</style>${template}`;
 
     const $btn: HTMLElement = $widget.querySelector(".asw-menu-btn");
@@ -28,7 +29,7 @@ export function renderWidget() {
 
     translateWidget();
 
-    document.body.appendChild($widget);
+    document.body.appendChild($host);
 
     return $widget;
 }


### PR DESCRIPTION
## Problem

Sienna currently renders its controls inside a light-DOM `.asw-container` appended to `document.body`. Because those controls participate in the host page’s CSS cascade, global styles can override the widget’s styles.

For example:

```css
button {
    white-space: nowrap;
}

.elementor-kit-689 button {
    border-radius: 50px;
    padding: 15px 45px;
    font-family: Verdana;
}
```

These rules turn the menu cards into oversized pills, change the typography, and clip button labels. The issue was found on an Elementor site, but it can occur with any theme, framework, page builder, or custom stylesheet that targets common elements.

## Before and after

**Before**

<img width="1280" height="900" alt="Sienna widget before Shadow DOM isolation" src="https://github.com/user-attachments/assets/af07ad47-eec7-4c17-9af6-17b480e9c647" />

**After**

<img width="1280" height="900" alt="Sienna widget after Shadow DOM isolation" src="https://github.com/user-attachments/assets/91d13dc3-1479-4d71-93c8-09d73db57cec" />

## Root cause

The widget’s stylesheet and the host page’s stylesheet share the same cascade. Increasing specificity would only address known collisions and require continued maintenance for new themes. A shadow root creates a style boundary around the widget’s internal elements.

## Changes

- Keep `.asw-container` in the page as the widget host.
- Attach an open shadow root and render the existing widget template and styles inside it.
- Establish a predictable host baseline with `:host { all: initial; ... }`. Shadow DOM prevents outside selectors from matching widget descendants, while the host reset establishes stable inherited typography and text defaults.
- Set an explicit system font stack for the existing `font-family: inherit` rules.
- Scope the font-size counter lookup to `$menu` instead of `document`.
- Pass `$menu` to the reset handler so selected button states are still cleared inside the shadow root.
- Leave page-level accessibility effects on `document`; contrast styles, reading-guide elements, and content transformations must continue to target the host page.

`ShadowRoot` supports the DOM methods already used by the widget, including `querySelector`, `querySelectorAll`, and `appendChild`, so the rendering and translation code does not require a larger rewrite.

## Validation

- `npm run build` passes.
- `git diff --check` passes.
- Tested in headless Chromium against a page containing the conflicting rules above.

| Property | Before | After |
| --- | --- | --- |
| Card `border-radius` | `50px` | `12px` |
| Card `padding` | `15px 45px` | `0 15px` |
| Font | Verdana | System font stack |
| `white-space` | `nowrap` | `normal` |

The before-and-after render confirms that labels are no longer clipped and the intended card geometry is restored.

## Existing lint status

Targeted ESLint on the changed TypeScript files reports two errors from the existing `// @ts-ignore` directives on line 1 of `widget.ts` and `renderMenu.ts`. Those lines are unchanged, and this PR introduces no additional targeted lint violations.

The repository-wide lint command also reports unrelated existing issues in `Languages.ts`, `cookies.ts`, and `screenReader.ts`.

## Compatibility

This change introduces an encapsulation boundary. External CSS selectors such as `.asw-container *` and JavaScript calls such as `document.querySelector('.asw-menu-btn')` will no longer reach widget internals.

The host page can still target `.asw-container` itself, but its selectors cannot cross into the shadow tree. Deliberate JavaScript access remains possible through the host’s open `shadowRoot`.

Integrations that currently style internal controls from the host page will need to remove that workaround or inject styles into the shadow root. This should be treated as a compatibility change when releasing.
